### PR TITLE
Fix/chatbot stock recommendation 챗봇 주식 추천 로직 수정

### DIFF
--- a/python/update_sp500.py
+++ b/python/update_sp500.py
@@ -85,9 +85,9 @@ def generate_current_to_high_ratio(current_price, high_price_1y):
 def generate_risk_level(dividend_yield, current_to_high_ratio):
     if dividend_yield is None or current_to_high_ratio is None:
         return None
-    if dividend_yield > 4.0 and current_to_high_ratio < 0.9:
+    if dividend_yield > 4.0 and current_to_high_ratio >= 0.9:
         return "LOW"
-    elif dividend_yield > 2.0 and current_to_high_ratio < 0.85:
+    elif dividend_yield > 2.0 and current_to_high_ratio >= 0.85:
         return "MEDIUM"
     else:
         return "HIGH"
@@ -96,9 +96,9 @@ def generate_risk_level(dividend_yield, current_to_high_ratio):
 # DB에 데이터 저장
 def save_to_db(conn, ticker, name, data):
     current_to_high_ratio = generate_current_to_high_ratio(data["current_price"], data["high_price_1y"])
-    risk_level = generate_risk_level(data["dividend_yield"], generate_current_to_high_ratio(data["current_price"], data["high_price_1y"]))
-    print("🔍 저장할 current_to_high_ratio:", current_to_high_ratio)
-    print("🔍 저장할 risk_level:", risk_level)
+    risk_level = generate_risk_level(data["dividend_yield"], current_to_high_ratio)
+    logging.debug("🔍 저장할 current_to_high_ratio:", current_to_high_ratio)
+    logging.debug("🔍 저장할 risk_level:", risk_level)
     
     with conn.cursor() as cursor:
         cursor.execute("""

--- a/python/update_sp500.py
+++ b/python/update_sp500.py
@@ -76,15 +76,37 @@ def get_stock_data(ticker):
     except Exception as e:
         print(f"❌ {ticker} 데이터 수집 실패:", e)
         return None
+    
+def generate_current_to_high_ratio(current_price, high_price_1y):
+    if current_price is None or high_price_1y in (None, 0):
+        return None
+    return current_price / high_price_1y
+
+def generate_risk_level(dividend_yield, current_to_high_ratio):
+    if dividend_yield is None or current_to_high_ratio is None:
+        return None
+    if dividend_yield > 4.0 and current_to_high_ratio < 0.9:
+        return "LOW"
+    elif dividend_yield > 2.0 and current_to_high_ratio < 0.85:
+        return "MEDIUM"
+    else:
+        return "HIGH"
+
 
 # DB에 데이터 저장
 def save_to_db(conn, ticker, name, data):
+    current_to_high_ratio = generate_current_to_high_ratio(data["current_price"], data["high_price_1y"])
+    risk_level = generate_risk_level(data["dividend_yield"], generate_current_to_high_ratio(data["current_price"], data["high_price_1y"]))
+    print("🔍 저장할 current_to_high_ratio:", current_to_high_ratio)
+    print("🔍 저장할 risk_level:", risk_level)
+    
     with conn.cursor() as cursor:
         cursor.execute("""
             INSERT INTO stock_recommendation (
                 ticker, name, current_price, high_price_6m,
-                high_price_1y, high_price_2y, high_price_5y, dividend_yield
-            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                high_price_1y, high_price_2y, high_price_5y, dividend_yield,
+                current_to_high_ratio, risk_level
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             ON CONFLICT (ticker) DO UPDATE SET
                 current_price = EXCLUDED.current_price,
                 high_price_6m = EXCLUDED.high_price_6m,
@@ -92,12 +114,15 @@ def save_to_db(conn, ticker, name, data):
                 high_price_2y = EXCLUDED.high_price_2y,
                 high_price_5y = EXCLUDED.high_price_5y,
                 dividend_yield = EXCLUDED.dividend_yield,
+                current_to_high_ratio = EXCLUDED.current_to_high_ratio,
+                risk_level = EXCLUDED.risk_level,
                 updated_at = CURRENT_TIMESTAMP
         """, (
             ticker, name,
             data["current_price"], data["high_price_6m"],
             data["high_price_1y"], data["high_price_2y"],
-            data["high_price_5y"], data["dividend_yield"]
+            data["high_price_5y"], data["dividend_yield"],
+            current_to_high_ratio, risk_level
         ))
     conn.commit()
 
@@ -111,13 +136,17 @@ def main():
         print(f"📊 {ticker} 수집 중...")
         data = get_stock_data(ticker)
         if data:
+            current_to_high_ratio = float_or_none(generate_current_to_high_ratio(data["current_price"], data["high_price_1y"]))
+            risk_level = generate_risk_level(data["dividend_yield"], current_to_high_ratio)
             clean_data = {
                 "current_price": float_or_none(data["current_price"]),
                 "high_price_6m": float_or_none(data["high_price_6m"]),
                 "high_price_1y": float_or_none(data["high_price_1y"]),
                 "high_price_2y": float_or_none(data["high_price_2y"]),
                 "high_price_5y": float_or_none(data["high_price_5y"]),
-                "dividend_yield": float_or_none(data["dividend_yield"])
+                "dividend_yield": float_or_none(data["dividend_yield"]),
+                "current_to_high_ratio": current_to_high_ratio,
+                "risk_level": risk_level
             }
             save_to_db(conn, ticker, name, clean_data)
             print(f"✅ {ticker} 저장 완료")

--- a/src/main/java/redlightBack/openAi/ChatBotPrompt.java
+++ b/src/main/java/redlightBack/openAi/ChatBotPrompt.java
@@ -4,67 +4,61 @@ public class ChatBotPrompt {
 
     //system 프롬프트 : 사용자기 입력한 내용에서 조건 추출
     public static final String systemMes_extractConditions = """
-    당신은 사용자의 주식 관련 질문을 분석하여, 다음 네 가지 조건을 추출하는 AI입니다.
-    사용자의 말투는 초보 투자자일 수 있으며, 전문 용어 대신 감정적·일상적 표현을 사용하는 경우가 많습니다.
+당신은 오직 **주식 추천 조건을 추출하는 도우미**입니다.
+주식 관련이 아닌 질문은 모두 무시하고 아래 규칙에 따라 반응하세요.
+사용자의 말투는 초보 투자자일 수 있으며, 전문 용어 대신 감정적·일상적 표현을 사용하는 경우가 많습니다.
 
-    추출해야 할 조건:
-    - "minDividend": 최소 배당률 (예: 4.0, 2.0, 0.0)
-    - "maxPriceRatio": 고점 대비 현재가 비율의 최대 허용치 (예: 0.85, 0.95, 1.0)
-    - "sortBy": 정렬 기준. 가능한 값은 "DIVIDEND", "PRICEGAP", "RISK"
-    - "sortDirection": 정렬 방향. 가능한 값은 "ASC", "DESC"
+추출해야 할 조건 (세 가지):
+- "minDividend": 최소 배당률 (예: 4.0, 2.0, 0.0)
+- "maxPriceRatio": 고점 대비 현재가 비율의 최대 허용치 (예: 0.85, 0.95, 1.0)
+- "riskLevel": 위험 성향 ("LOW", "MEDIUM", "HIGH")
 
-    아래 판단 기준을 철저히 따르세요:
+아래 기준에 따라 사용자의 표현을 정량적 조건으로 정확히 변환하세요.
 
-    ──────── 배당 관련 표현 ────────
-    - "고배당", "배당 잘 나오는", "배당 높은" → minDividend = 4.0
-    - "배당 있으면 좋겠다", "조금이라도 배당" → minDividend = 2.0
-    - 배당 언급 없음 또는 "배당 필요 없어" → minDividend = 0.0
+──────── 배당 관련 표현 ────────
+- "고배당", "배당 잘 나오는", "배당 높은" → minDividend = 4.0
+- "배당 있으면 좋겠다", "조금이라도 배당" → minDividend = 2.0
+- 배당 언급 없음 또는 "배당 필요 없어" → minDividend = 0.0
 
-    ──────── 가격 관련 표현 ────────
-    - "저평가", "싸게 살 수 있는", "많이 빠진" → maxPriceRatio = 0.85
-    - "지금 사도 괜찮은", "조정된 가격" → maxPriceRatio = 0.95
-    - 가격 언급 없음 또는 "지금 올라타자" → maxPriceRatio = 1.0
+──────── 가격 관련 표현 ────────
+- "저평가", "싸게 살 수 있는", "많이 빠진" → maxPriceRatio = 0.85
+- "지금 사도 괜찮은", "조정된 가격" → maxPriceRatio = 0.95
+- 가격 언급 없음 또는 "지금 올라타자" → maxPriceRatio = 1.0
 
-    ──────── 정렬 관련 표현 ────────
-    - "배당 순", "배당 높은 순" → sortBy = "DIVIDEND", sortDirection = "DESC"
-    - "저평가 순", "싸게 내려간 순" → sortBy = "PRICEGAP", sortDirection = "ASC"
-    - "위험도 높은 순", "리스크 큰 순" → sortBy = "RISK", sortDirection = "DESC"
-    - "위험도 낮은 순", "안전한 종목 순" → sortBy = "RISK", sortDirection = "ASC"
-    - 별도 언급이 없으면 sortBy = "DIVIDEND", sortDirection = "DESC"
+──────── 위험 성향 표현 ────────
+- "안정적인", "잃기 싫어", "무서워", "지켜야 하는 돈" → riskLevel = "LOW"
+- "적당히 수익", "크게 오르진 않아도", "중간 정도" → riskLevel = "MEDIUM"
+- "공격적", "대박", "급등주", "모 아니면 도" → riskLevel = "HIGH"
 
-    ──────── 감정 기반 표현 조합 ────────
-    - "안정적인", "잃기 싫어", "무서워" → sortBy = "RISK", sortDirection = "ASC", maxPriceRatio = 0.9
-    - "적당히 수익", "크게 오르진 않아도" → sortBy = "RISK", sortDirection = "ASC", maxPriceRatio = 0.95
-    - "공격적", "대박", "급등주" → sortBy = "RISK", sortDirection = "DESC", maxPriceRatio = 1.0
+──────── 복합적 문장 해석 예시 ────────
+- "안정적인 고배당 종목 추천해줘"
+  → minDividend = 4.0, maxPriceRatio = 0.9, riskLevel = "LOW"
 
-    ──────── 투자 기간 표현 ────────
-    - "오래 묻어둘", "잊어버려도 되는", "장기" → minDividend = 4.0, maxPriceRatio = 0.9
-    - "단타", "단기간 수익", "지금 사고 곧 파는" → minDividend = 0.0, maxPriceRatio = 1.0
+- "싸게 떨어진 주식 중에서 수익 좀 낼 수 있는 거"
+  → maxPriceRatio = 0.85, minDividend = 2.0, riskLevel = "MEDIUM"
 
-    ──────── 신뢰 기반 표현 ────────
-    - "연금처럼", "소득형", "부모님께 추천할", "지인에게 소개할" → minDividend = 4.0, maxPriceRatio = 0.9
+──────── 지원하지 않는 질문에 대한 응답 규칙 ────────
+❶ 주식 외 일상 질문이 포함된 경우 (예: 점심 메뉴, 날씨, 선물 추천 등):
+→ 반드시 JSON이 아닌 문자열로 아래와 같이 응답하세요:
+"저는 주식 추천 AI입니다. 주식 관련 질문을 해 주세요."
 
-    ──────────────── 시스템에서 지원하지 않는 조건 (금지) ────────────────
-    아래 조건이 언급되더라도 절대로 고려하거나 반영하지 마세요.
-    - 산업군 (예: AI, 헬스케어 등)
-    - ETF, 펀드 등 개별 종목이 아닌 상품
-    - 뉴스 기반 추천, 검색량, 실시간 주가
-    - 실적 정보 (PER, EPS, ROE 등)
+❷ 분석 대상 제외 항목:
+- 산업군 (AI, 헬스케어 등)
+- ETF, 펀드 등 종목 외 상품
+- 실적(PER, EPS), 뉴스, 실시간 검색량 기반 추천 등
 
-    ──────── 반드시 지켜야 할 응답 형식 ────────
-    JSON 형식으로만 응답하세요. 다른 설명이나 주석은 금지합니다.
-    모든 키는 **문자열**로, 값은 JSON 표준 타입으로만 사용하세요.
-    - sortBy: 반드시 "DIVIDEND", "PRICEGAP", "RISK" 중 하나
-    - sortDirection: 반드시 "ASC", "DESC" 중 하나
+──────── 반드시 지켜야 할 응답 형식 ────────
+JSON 형식으로만 응답하세요. 다른 설명이나 주석은 금지합니다.
+모든 키는 **문자열**로, 값은 JSON 표준 타입으로만 사용하세요.
 
-    예시 출력:
-    {
-      "minDividend": 4.0,
-      "maxPriceRatio": 0.85,
-      "sortBy": "PRICEGAP",
-      "sortDirection": "ASC"
-    }
-    """;
+예시 출력:
+{
+  "minDividend": 4.0,
+  "maxPriceRatio": 0.85,
+  "riskLevel": "LOW"
+}
+""";
+
 
 
     //system 프롬프트 : 사용자에게 추천 결과 설명용

--- a/src/main/java/redlightBack/openAi/ChatController.java
+++ b/src/main/java/redlightBack/openAi/ChatController.java
@@ -7,8 +7,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import redlightBack.stockRecommendation.StockRecommendationService;
-import redlightBack.stockRecommendation.dto.SortBy;
-import redlightBack.stockRecommendation.dto.SortDirection;
+import redlightBack.stockRecommendation.dto.RiskLevel;
 import redlightBack.stockRecommendation.dto.StockRecommendationAndExplanationResponse;
 
 import java.util.Map;
@@ -38,11 +37,10 @@ public class ChatController {
         Map<String, Object> condition = objectMapper.readValue(conditionJson, Map.class);
 
         double minDividend = Double.parseDouble(condition.get("minDividend").toString());
-        double macPriceRatio = Double.parseDouble(condition.get("maxPriceRatio").toString());
-        SortBy sortBy = SortBy.valueOf(condition.get("sortBy").toString().toUpperCase());
-        SortDirection sortDirection = SortDirection.valueOf(condition.get("sortDirection").toString().toUpperCase());
+        double maxPriceRatio = Double.parseDouble(condition.get("maxPriceRatio").toString());
+        RiskLevel riskLevel = RiskLevel.valueOf(condition.get("riskLevel").toString().toUpperCase());
 
         //조건 기반 추천 로직 + GPT 설명
-        return stockRecommendationService.getRecommendWithExplanation(minDividend, macPriceRatio, sortBy, sortDirection, 3);
+        return stockRecommendationService.getRecommendWithExplanation(minDividend, maxPriceRatio, riskLevel, 3);
     }
 }

--- a/src/main/java/redlightBack/openAi/dto/StockForChatBotDto.java
+++ b/src/main/java/redlightBack/openAi/dto/StockForChatBotDto.java
@@ -1,6 +1,6 @@
 package redlightBack.openAi.dto;
 
-import redlightBack.stockRecommendation.dto.RiskLevel;
+import redlightBack.stockRecommendation.RiskLevel;
 
 public record StockForChatBotDto(String name,
                                  String recommendReason,

--- a/src/main/java/redlightBack/openAi/dto/StockForChatBotDto.java
+++ b/src/main/java/redlightBack/openAi/dto/StockForChatBotDto.java
@@ -1,8 +1,10 @@
 package redlightBack.openAi.dto;
 
+import redlightBack.stockRecommendation.dto.RiskLevel;
+
 public record StockForChatBotDto(String name,
                                  String recommendReason,
                                  String detail,
-                                 String riskLevel) {
+                                 RiskLevel riskLevel) {
 }
 

--- a/src/main/java/redlightBack/stockRecommendation/RiskLevel.java
+++ b/src/main/java/redlightBack/stockRecommendation/RiskLevel.java
@@ -1,4 +1,4 @@
-package redlightBack.stockRecommendation.dto;
+package redlightBack.stockRecommendation;
 
 public enum RiskLevel {
     LOW,

--- a/src/main/java/redlightBack/stockRecommendation/StockInfoQueryRepository.java
+++ b/src/main/java/redlightBack/stockRecommendation/StockInfoQueryRepository.java
@@ -4,7 +4,6 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-import redlightBack.stockRecommendation.dto.RiskLevel;
 
 import java.util.List;
 

--- a/src/main/java/redlightBack/stockRecommendation/StockInfoQueryRepository.java
+++ b/src/main/java/redlightBack/stockRecommendation/StockInfoQueryRepository.java
@@ -1,15 +1,10 @@
 package redlightBack.stockRecommendation;
 
-import com.querydsl.core.types.Order;
-import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.CaseBuilder;
-import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-import redlightBack.stockRecommendation.dto.SortBy;
-import redlightBack.stockRecommendation.dto.SortDirection;
+import redlightBack.stockRecommendation.dto.RiskLevel;
 
 import java.util.List;
 
@@ -22,54 +17,33 @@ public class StockInfoQueryRepository {
     private final QStockRecommendation qStockRecommendation = QStockRecommendation.stockRecommendation;
 
 
-    public List<StockRecommendation> recommend(Double minDividend, Double maxPriceRatio, SortBy sortBy, SortDirection sortDirection, int limit){
+    public List<StockRecommendation> recommend(Double minDividend,
+                                               Double maxPriceRatio,
+                                               RiskLevel riskLevel,
+                                               int limit){
         return queryFactory.selectFrom(qStockRecommendation)
-                .where(byDividend(minDividend), byPriceRatio(maxPriceRatio))
-                .orderBy(orderSpecifier(sortBy, sortDirection))
+                .where(byDividend(minDividend),
+                        byPriceRatio(maxPriceRatio),
+                        byRiskLevel(riskLevel))
+                .orderBy(qStockRecommendation.dividendYield.desc())
                 .limit(limit)
                 .fetch();
     }
 
     // 	배당률이 최소 기준 이상인 종목
     private BooleanExpression byDividend(Double min){
-        return (min != null) ? qStockRecommendation.dividendYield.gt(min) : null;
+        return (min != null) ? qStockRecommendation.dividendYield.goe(min) : null;
     }
 
     // 기간 고점 대비 저평가된 종목
     // 예: maxRatio = 0.8 이면, 현재가가 1년 고가의 80% 이하인 종목만 반환
     private BooleanExpression byPriceRatio(Double maxRatio){
-        return (maxRatio != null) ? qStockRecommendation.currentPrice.divide(qStockRecommendation.highPrice1y).lt(maxRatio) : null;
+        return (maxRatio != null) ? qStockRecommendation.currentPrice.divide(qStockRecommendation.highPrice1y).loe(maxRatio) : null;
     }
 
-    private OrderSpecifier<?> orderSpecifier (SortBy sortBy, SortDirection sortDirection){
-
-        Order direction = Order.valueOf(sortDirection.name());
-
-        if(sortBy == SortBy.PRICEGAP){
-            return new OrderSpecifier<>(
-                    direction,
-                    qStockRecommendation.currentPrice.divide(qStockRecommendation.highPrice1y)
-            );
-        } else if(sortBy == SortBy.RISK){
-                    NumberExpression<Integer> riskScore = new CaseBuilder()
-                            .when(
-                                    qStockRecommendation.dividendYield.gt(4.0)
-                                            .and(qStockRecommendation.currentPrice.divide(qStockRecommendation.highPrice1y).gt(0.9))
-                            ).then(0)
-                            .when(qStockRecommendation.dividendYield.gt(2.0)
-                                    .and(qStockRecommendation.currentPrice.divide((qStockRecommendation.highPrice1y)).gt(0.85))
-                            ).then(1)
-                            .otherwise(2);
-
-                    return new OrderSpecifier<>(direction, riskScore);
-        }else{
-            return new OrderSpecifier<>(
-                    direction,
-                    qStockRecommendation.dividendYield
-            );
-        }
+    //위험도 조건
+    private BooleanExpression byRiskLevel(RiskLevel level){
+        return (level != null) ? qStockRecommendation.riskLevel.eq(level) : null;
     }
-
-
 
 }

--- a/src/main/java/redlightBack/stockRecommendation/StockRecommendation.java
+++ b/src/main/java/redlightBack/stockRecommendation/StockRecommendation.java
@@ -58,7 +58,7 @@ public class StockRecommendation {
         if(dividendYield != null && dividendYield > 4){
             reasons.add(Tag.고배당.toString());
         }
-        if(generatePriceGapRatio() < 0.85){
+        if(currentToHighRatio < 0.85){
             reasons.add(Tag.저평가.toString());
         }
         return String.join("+", reasons);
@@ -86,8 +86,8 @@ public class StockRecommendation {
             String formattedYield = String.format("배당률 %.2f%%", dividendYield);
             details.add(formattedYield);
         }
-        if(generatePriceGapRatio() < 1.0){
-            double dropPercent = (1.0 - generatePriceGapRatio()) * 100;
+        if(currentToHighRatio < 1.0){
+            double dropPercent = (1.0 - currentToHighRatio) * 100;
             String formattedDrop = String.format("고점 대비 -%.0f%%", dropPercent);
             details.add(formattedDrop);
         }

--- a/src/main/java/redlightBack/stockRecommendation/StockRecommendation.java
+++ b/src/main/java/redlightBack/stockRecommendation/StockRecommendation.java
@@ -47,11 +47,6 @@ public class StockRecommendation {
 
     private LocalDateTime updatedAt;
 
-    //고점 대비 저평가율
-    public Double generatePriceGapRatio (){
-        return currentPrice / highPrice1y;
-    }
-
     //"고배당 + 저평가" 태그 생성
     public String generateReason(){
         List<String> reasons = new ArrayList<>();
@@ -62,20 +57,6 @@ public class StockRecommendation {
             reasons.add(Tag.저평가.toString());
         }
         return String.join("+", reasons);
-    }
-
-    //위험성향 판단
-    public RiskLevel generateRiskLevel(){
-
-        double ratio = generatePriceGapRatio();
-
-        if(dividendYield != null && dividendYield > 4 && ratio > 0.9){
-            return RiskLevel.LOW;
-        }else if(dividendYield != null && dividendYield > 2 && ratio > 0.85){
-            return RiskLevel.MEDIUM;
-        }else {
-            return RiskLevel.HIGH;
-        }
     }
 
     //챗봇에 넘길 문장 생성

--- a/src/main/java/redlightBack/stockRecommendation/StockRecommendation.java
+++ b/src/main/java/redlightBack/stockRecommendation/StockRecommendation.java
@@ -40,6 +40,11 @@ public class StockRecommendation {
 
     private Double dividendYield;  //연배당수익률
 
+    private Double currentToHighRatio;  //저평가율
+
+    @Enumerated(EnumType.STRING)
+    private RiskLevel riskLevel;  //위험도
+
     private LocalDateTime updatedAt;
 
     //고점 대비 저평가율

--- a/src/main/java/redlightBack/stockRecommendation/StockRecommendation.java
+++ b/src/main/java/redlightBack/stockRecommendation/StockRecommendation.java
@@ -2,7 +2,6 @@ package redlightBack.stockRecommendation;
 
 import jakarta.persistence.*;
 import lombok.*;
-import redlightBack.stockRecommendation.dto.RiskLevel;
 import redlightBack.stockRecommendation.dto.Tag;
 
 import java.time.LocalDateTime;

--- a/src/main/java/redlightBack/stockRecommendation/StockRecommendationController.java
+++ b/src/main/java/redlightBack/stockRecommendation/StockRecommendationController.java
@@ -4,10 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import redlightBack.stockRecommendation.dto.SortBy;
-import redlightBack.stockRecommendation.dto.SortDirection;
-import redlightBack.stockRecommendation.dto.StockRecommendationAndExplanationResponse;
-import redlightBack.stockRecommendation.dto.StockRecommendationResponse;
+import redlightBack.stockRecommendation.dto.*;
 
 import java.util.List;
 

--- a/src/main/java/redlightBack/stockRecommendation/StockRecommendationController.java
+++ b/src/main/java/redlightBack/stockRecommendation/StockRecommendationController.java
@@ -21,22 +21,20 @@ public class StockRecommendationController {
     @GetMapping("stock-recommendations")
     public List<StockRecommendationResponse> getRecommendations (@RequestParam(required = false) Double dividendMin,
                                                                  @RequestParam(required = false) Double priceRatioMax,
-                                                                 @RequestParam(required = false) SortBy sortBy,
-                                                                 @RequestParam(required = false) SortDirection sortDirection,
+                                                                 @RequestParam(required = false) RiskLevel riskLevel,
                                                                  @RequestParam(required = false, defaultValue = "3") Integer limit){
 
-        return stockInfoService.getRecommend(dividendMin, priceRatioMax, sortBy, sortDirection, limit);
+        return stockInfoService.getRecommend(dividendMin, priceRatioMax, riskLevel, limit);
     }
 
     //GPT한테 넘기는 주식 추천 List
     @GetMapping("/stock-recommendations-with-gpt")
     public StockRecommendationAndExplanationResponse getRecommendationsWithGpt (@RequestParam(required = false) Double dividendMin,
                                                                                 @RequestParam(required = false) Double priceRatioMax,
-                                                                                @RequestParam(required = false) SortBy sortBy,
-                                                                                @RequestParam(required = false) SortDirection sortDirection,
+                                                                                @RequestParam(required = false) RiskLevel riskLevel,
                                                                                 @RequestParam(required = false, defaultValue = "3") Integer limit){
 
-        return stockInfoService.getRecommendWithExplanation(dividendMin, priceRatioMax, sortBy, sortDirection, limit);
+        return stockInfoService.getRecommendWithExplanation(dividendMin, priceRatioMax, riskLevel, limit);
     }
 
 }

--- a/src/main/java/redlightBack/stockRecommendation/StockRecommendationService.java
+++ b/src/main/java/redlightBack/stockRecommendation/StockRecommendationService.java
@@ -4,10 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import redlightBack.openAi.OpenAiService;
 import redlightBack.openAi.dto.StockForChatBotDto;
-import redlightBack.stockRecommendation.dto.SortBy;
-import redlightBack.stockRecommendation.dto.SortDirection;
-import redlightBack.stockRecommendation.dto.StockRecommendationAndExplanationResponse;
-import redlightBack.stockRecommendation.dto.StockRecommendationResponse;
+import redlightBack.stockRecommendation.dto.*;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -22,15 +19,13 @@ public class StockRecommendationService {
 
 
     //추천 받은 주식 list return
-    public List<StockRecommendationResponse> getRecommend (Double minDividend, Double maxPriceRatio, SortBy sortBy, SortDirection sortDirection, int limit){
-        List<StockRecommendation> recommend = stockInfoQueryRepository.recommend(minDividend, maxPriceRatio, sortBy, sortDirection, limit);
+    public List<StockRecommendationResponse> getRecommend (Double minDividend, Double maxPriceRatio, RiskLevel riskLevel,  int limit){
+        List<StockRecommendation> recommend = stockInfoQueryRepository.recommend(minDividend, maxPriceRatio, riskLevel, limit);
 
         return recommend.stream().map(
                 stock -> {
-                    Double ratio = stock.generatePriceGapRatio();
                     String reason = stock.generateReason();
                     String detail = stock.generateDetail();
-                    String riskLevel = stock.generateRiskLevel().name();
 
                     return new StockRecommendationResponse(
                             stock.getId(),
@@ -39,17 +34,17 @@ public class StockRecommendationService {
                             stock.getCurrentPrice(),
                             round(stock.getHighPrice1y(), 2),
                             round(stock.getDividendYield(), 2),
-                            round(ratio, 3),
-                            reason,
+                            round(maxPriceRatio, 3),
                             riskLevel,
+                            reason,
                             detail
                     );
                 }).toList();
     }
 
     //추천 받은 주식 list를 gpt에 넘기는 로직
-    public StockRecommendationAndExplanationResponse getRecommendWithExplanation(Double minDividend, Double maxPriceRatio, SortBy sortBy, SortDirection sortDirection, int limit){
-        List<StockRecommendationResponse> stocks = getRecommend(minDividend, maxPriceRatio, sortBy, sortDirection, limit);
+    public StockRecommendationAndExplanationResponse getRecommendWithExplanation(Double minDividend, Double maxPriceRatio, RiskLevel riskLevel, int limit){
+        List<StockRecommendationResponse> stocks = getRecommend(minDividend, maxPriceRatio, riskLevel, limit);
 
         List<StockForChatBotDto> forChatBot = stocks.stream().map(stock -> new StockForChatBotDto(
                 stock.name(),

--- a/src/main/java/redlightBack/stockRecommendation/StockRecommendationService.java
+++ b/src/main/java/redlightBack/stockRecommendation/StockRecommendationService.java
@@ -34,7 +34,7 @@ public class StockRecommendationService {
                             stock.getCurrentPrice(),
                             round(stock.getHighPrice1y(), 2),
                             round(stock.getDividendYield(), 2),
-                            round(maxPriceRatio, 3),
+                            round(stock.getCurrentToHighRatio(), 3),
                             riskLevel,
                             reason,
                             detail

--- a/src/main/java/redlightBack/stockRecommendation/dto/SortBy.java
+++ b/src/main/java/redlightBack/stockRecommendation/dto/SortBy.java
@@ -1,7 +1,0 @@
-package redlightBack.stockRecommendation.dto;
-
-public enum SortBy {
-    DIVIDEND,  //배당률
-    PRICEGAP,  //평가율
-    RISK  //위험성향
-}

--- a/src/main/java/redlightBack/stockRecommendation/dto/SortDirection.java
+++ b/src/main/java/redlightBack/stockRecommendation/dto/SortDirection.java
@@ -1,6 +1,0 @@
-package redlightBack.stockRecommendation.dto;
-
-public enum SortDirection {
-    ASC,  //오름차순
-    DESC  //내림차순
-}

--- a/src/main/java/redlightBack/stockRecommendation/dto/StockRecommendationResponse.java
+++ b/src/main/java/redlightBack/stockRecommendation/dto/StockRecommendationResponse.java
@@ -1,5 +1,7 @@
 package redlightBack.stockRecommendation.dto;
 
+import redlightBack.stockRecommendation.RiskLevel;
+
 public record StockRecommendationResponse(Long id,
                                           String ticker,
                                           String name,

--- a/src/main/java/redlightBack/stockRecommendation/dto/StockRecommendationResponse.java
+++ b/src/main/java/redlightBack/stockRecommendation/dto/StockRecommendationResponse.java
@@ -6,9 +6,9 @@ public record StockRecommendationResponse(Long id,
                                           Double currentPrice,
                                           Double highPrice1y,
                                           Double dividendYield,
-                                          Double priceGapRatio,
+                                          Double currentToHighRatio,
+                                          RiskLevel riskLevel,
                                           String recommendReason,
-                                          String riskLevel,
                                           String detail
                                 ) {
 }


### PR DESCRIPTION
- 파이썬 크롤링 단계에서 저평가율과 위험성향 계산 후 DB 저장
- 주식 추천 로직에서 사용자 입력 조건 조회만으로 추천 할 수 있도록 조회, 정렬 조건 변경